### PR TITLE
tweak license tag to BSD2

### DIFF
--- a/zlib-bindings.cabal
+++ b/zlib-bindings.cabal
@@ -1,6 +1,6 @@
 name:            zlib-bindings
 version:         0.1.1.5
-license:         BSD3
+license:         BSD2
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
 maintainer:      Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
The included license actually has 2 clauses not 3

[skip ci]